### PR TITLE
fix: ensure notifications timeout while system is idle

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -46,7 +46,6 @@ export default class NotificationTimeoutExtension extends Extension {
         ignoreIdle = this._settings.get_boolean("ignore-idle");
         alwaysNormal = this._settings.get_boolean("always-normal");
         newTimeout = this._settings.get_int("timeout");
-
     }
 
     _modifiedUpdateNotificationTimeout(timeout) {
@@ -56,15 +55,25 @@ export default class NotificationTimeoutExtension extends Extension {
 
         /* call the original _updateNotificationTimeout with new timeout */
         this._updateNotificationTimeoutOrig(timeout);
-    }
 
-    _modifiedUpdateStatus() {
+        // Force active state immediately when notification timeout is set
+        // This ensures the initial timer is respected even if the user is currently idle
         if (ignoreIdle) {
             this._userActiveWhileNotificationShown = true;
         }
+    }
 
-        /* call the original _updateState anyway */
+    _modifiedUpdateStatus() {
+        /* call the original _updateState first */
+        // This calculates the standard idle state based on mouse movement and resets _userActiveWhileNotificationShown
         this._updateStateOrig();
+
+        // Override the result AFTER the original function runs.
+        // If we do this before, _updateStateOrig will overwrite our true back to false
+        // if the user hasn't moved the mouse.
+        if (ignoreIdle) {
+            this._userActiveWhileNotificationShown = true;
+        }
     }
 
     _modifiedSetUrgency(urgency) {
@@ -109,25 +118,33 @@ export default class NotificationTimeoutExtension extends Extension {
     }
 
     disable() {
-        this._settings.disconnect(this._settingsConnectId);
-        this._settings = null;
+        if (this._settings) {
+            this._settings.disconnect(this._settingsConnectId);
+            this._settings = null;
+        }
 
         /**
-         * Reveret change _updateNotificationTimeout()
+         * Revert change _updateNotificationTimeout()
          */
-        MessageTray.MessageTray.prototype._updateNotificationTimeout = MessageTray.MessageTray.prototype._updateNotificationTimeoutOrig;
-        delete MessageTray.MessageTray.prototype._updateNotificationTimeoutOrig;
+        if (MessageTray.MessageTray.prototype._updateNotificationTimeoutOrig) {
+            MessageTray.MessageTray.prototype._updateNotificationTimeout = MessageTray.MessageTray.prototype._updateNotificationTimeoutOrig;
+            delete MessageTray.MessageTray.prototype._updateNotificationTimeoutOrig;
+        }
 
         /**
-         * Reveret change _updateState()
+         * Revert change _updateState()
          */
-        MessageTray.MessageTray.prototype._updateState = MessageTray.MessageTray.prototype._updateStateOrig;
-        delete MessageTray.MessageTray.prototype._updateStateOrig;
+        if (MessageTray.MessageTray.prototype._updateStateOrig) {
+            MessageTray.MessageTray.prototype._updateState = MessageTray.MessageTray.prototype._updateStateOrig;
+            delete MessageTray.MessageTray.prototype._updateStateOrig;
+        }
 
         /**
-         * Reveret change setUrgency()
+         * Revert change setUrgency()
          */
-        MessageTray.Notification.prototype.setUrgency = MessageTray.Notification.prototype._setUrgencyOrig;
-        delete MessageTray.Notification.prototype._setUrgencyOrig;
+        if (MessageTray.Notification.prototype._setUrgencyOrig) {
+            MessageTray.Notification.prototype.setUrgency = MessageTray.Notification.prototype._setUrgencyOrig;
+            delete MessageTray.Notification.prototype._setUrgencyOrig;
+        }
     }
 }

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -56,23 +56,17 @@ export default class NotificationTimeoutExtension extends Extension {
         /* call the original _updateNotificationTimeout with new timeout */
         this._updateNotificationTimeoutOrig(timeout);
 
-        // Force active state immediately when notification timeout is set
-        // This ensures the initial timer is respected even if the user is currently idle
+        // CHANGE: Fix idle detection without crashing the loop.
+        // Instead of patching _updateState (which runs every second and causes crashes),
+        // we simply tell the tray that a user action happened *right now* when the notification appears.
         if (ignoreIdle) {
             this._userActiveWhileNotificationShown = true;
-        }
-    }
-
-    _modifiedUpdateStatus() {
-        /* call the original _updateState first */
-        // This calculates the standard idle state based on mouse movement and resets _userActiveWhileNotificationShown
-        this._updateStateOrig();
-
-        // Override the result AFTER the original function runs.
-        // If we do this before, _updateStateOrig will overwrite our true back to false
-        // if the user hasn't moved the mouse.
-        if (ignoreIdle) {
-            this._userActiveWhileNotificationShown = true;
+            
+            // Updating the timestamp ensures that the next native _updateState check 
+            // calculates "idle time" as 0, preventing it from resetting the active flag.
+            if (global.get_current_time) {
+                this._lastUserActionTime = global.get_current_time();
+            }
         }
     }
 
@@ -105,12 +99,6 @@ export default class NotificationTimeoutExtension extends Extension {
         MessageTray.MessageTray.prototype._updateNotificationTimeout = this._modifiedUpdateNotificationTimeout;
 
         /**
-         * Change _updateState()
-         */
-        MessageTray.MessageTray.prototype._updateStateOrig = MessageTray.MessageTray.prototype._updateState;
-        MessageTray.MessageTray.prototype._updateState = this._modifiedUpdateStatus;
-
-        /**
          * Change setUrgency()
          */
         MessageTray.Notification.prototype._setUrgencyOrig = MessageTray.Notification.prototype.setUrgency;
@@ -129,14 +117,6 @@ export default class NotificationTimeoutExtension extends Extension {
         if (MessageTray.MessageTray.prototype._updateNotificationTimeoutOrig) {
             MessageTray.MessageTray.prototype._updateNotificationTimeout = MessageTray.MessageTray.prototype._updateNotificationTimeoutOrig;
             delete MessageTray.MessageTray.prototype._updateNotificationTimeoutOrig;
-        }
-
-        /**
-         * Revert change _updateState()
-         */
-        if (MessageTray.MessageTray.prototype._updateStateOrig) {
-            MessageTray.MessageTray.prototype._updateState = MessageTray.MessageTray.prototype._updateStateOrig;
-            delete MessageTray.MessageTray.prototype._updateStateOrig;
         }
 
         /**


### PR DESCRIPTION
Previously, the extension set _userActiveWhileNotificationShown to true before calling the original _updateState. GNOME Shell's native logic checks the actual input idle time inside _updateState and resets this flag to false if the user hasn't moved the mouse (e.g., while watching a video), causing notifications to persist indefinitely.

This patch moves the override to occur after the original _updateState call. This forces the message tray to respect the timeout timer by treating the user as active for notification purposes, even if the system reports them as idle.

Also, i removed the loop patching, since it was crashing GNOME Notifications system silently. Instead, i've implemented a initialization which runs once per notification.